### PR TITLE
Update GCCompact heuristic advice

### DIFF
--- a/lib/autotuner/heuristic/gc_compact.rb
+++ b/lib/autotuner/heuristic/gc_compact.rb
@@ -43,9 +43,13 @@ module Autotuner
 
           For example, in Puma, add the following code into config/puma.rb:
 
+            compacted = false
             before_fork do
-              3.times { GC.start }
-              GC.compact
+              unless compacted
+                3.times { GC.start }
+                GC.compact
+                compacted = true
+              end
             end
         MSG
       end


### PR DESCRIPTION
Compacting before every fork is counter productive as it risks writing into many pages every time, invalidating lots of pages that were shared with the previous forked childs.

Issue reported by @beauraF 

![image](https://github.com/Shopify/autotuner/assets/19192189/b24d4ea5-dc2b-4a61-971a-d0ce2e429b56)
