### PR TITLE
Make `GC.compact` suggestion conditional by `before_fork` behaviour

### DIFF
--- a/lib/autotuner/heuristic/gc_compact.rb
+++ b/lib/autotuner/heuristic/gc_compact.rb
@@ -41,10 +41,18 @@ module Autotuner
             3.times { GC.start }
             GC.compact
 
-          For example, in Puma, add the following code into config/puma.rb:
+          For example, with Puma, which runs its before fork hook once on boot (before the initial fork), add the following code into config/puma.rb:
+
+            before_fork do
+              3.times { GC.start }
+              GC.compact
+            end
+
+          With Unicorn, which runs its before fork hook before each fork, add the following code into config/unicorn.rb:
 
             compacted = false
             before_fork do
+              # avoid invalidating heap pages shared with previously forked children
               unless compacted
                 3.times { GC.start }
                 GC.compact


### PR DESCRIPTION
The amendment made in #7 isn't applicable to puma which runs its `before_fork` hook [once on boot](https://github.com/puma/puma/blob/3169cf607ae3978eabf22c325f02eaefc8ca5c45/lib/puma/dsl.rb#L616-L617). Since the suggestion specifically mentions puma it might be confusing to end users.

I've updated the suggestion to include an example for both puma and unicorn, which should hopefully make it clear that the logic the end user implements should be dependent on when their `before_fork` hook runs.