### PR TITLE
expose heuristic_name in report

### DIFF
--- a/lib/autotuner/heuristic/gc_compact.rb
+++ b/lib/autotuner/heuristic/gc_compact.rb
@@ -31,7 +31,7 @@ module Autotuner
         # Don't give suggestion twice
         @called_gc_compact = true
 
-        Report::String.new(<<~MSG)
+        Report::String.new(name, <<~MSG)
           The following suggestion runs compaction at boot time, which reduces fragmentation inside of the Ruby heap. This can improve performance and reduce memory usage in forking web servers.
 
           Before forking your web server, run the following Ruby code:

--- a/lib/autotuner/heuristic/heap_size_warmup.rb
+++ b/lib/autotuner/heuristic/heap_size_warmup.rb
@@ -97,7 +97,13 @@ module Autotuner
         # Don't generate report if there is nothing to report
         return if suggested_values.empty?
 
-        Report::MultipleEnvironmentVariables.new(REPORT_ASSIST_MESSAGE, env_names, suggested_values, configured_values)
+        Report::MultipleEnvironmentVariables.new(
+          name,
+          REPORT_ASSIST_MESSAGE,
+          env_names,
+          suggested_values,
+          configured_values,
+        )
       end
 
       def debug_state

--- a/lib/autotuner/heuristic/malloc.rb
+++ b/lib/autotuner/heuristic/malloc.rb
@@ -65,6 +65,7 @@ module Autotuner
         @given_suggestion = true
 
         Report::MultipleEnvironmentVariables.new(
+          name,
           <<~MSG,
             The following suggestions reduce the number of minor garbage collection cycles, specifically a cycle called "malloc". Your app runs malloc cycles in approximately #{format("%.2f", malloc_gc_ratio * 100)}% of all minor garbage collection cycles.
 

--- a/lib/autotuner/heuristic/oldmalloc.rb
+++ b/lib/autotuner/heuristic/oldmalloc.rb
@@ -64,6 +64,7 @@ module Autotuner
         @given_suggestion = true
 
         Report::MultipleEnvironmentVariables.new(
+          name,
           <<~MSG,
             The following suggestions reduce the number of major garbage collection cycles, specifically a cycle called "oldmalloc". Your app runs oldmalloc cycles in approximately #{format("%.2f", oldmalloc_gc_ratio * 100)}% of all major garbage collection cycles.
 

--- a/lib/autotuner/heuristic/remembered_wb_unprotected_objects.rb
+++ b/lib/autotuner/heuristic/remembered_wb_unprotected_objects.rb
@@ -62,6 +62,7 @@ module Autotuner
         @given_suggestion = true
 
         Report::SingleEnvironmentVariable.new(
+          name,
           <<~MSG,
             The following suggestions reduce the number of major garbage collection cycles, specifically a cycle called "remembered write barrier unprotected" (also know as "shady" due to historical reasons). Your app runs remembered write barrier unprotected cycles in approximately #{format("%.2f", wb_unprotected_gc_ratio * 100)}% of all major garbage collection cycles.
 

--- a/lib/autotuner/report/base.rb
+++ b/lib/autotuner/report/base.rb
@@ -7,9 +7,10 @@ module Autotuner
         It is always recommended to experiment with these suggestions as some suggestions may not always yield positive performance improvements. The recommended method is to perform A/B testing where a portion of traffic does not have the these suggested values and a portion of traffic with these suggested values.
       MSG
 
-      attr_reader :assist_message
+      attr_reader :heuristic_name, :assist_message
 
-      def initialize(assist_message)
+      def initialize(heuristic_name, assist_message)
+        @heuristic_name = heuristic_name
         @assist_message = assist_message
       end
 

--- a/lib/autotuner/report/multiple_environment_variables.rb
+++ b/lib/autotuner/report/multiple_environment_variables.rb
@@ -7,8 +7,8 @@ module Autotuner
       attr_reader :suggested_value
       attr_reader :configured_value
 
-      def initialize(assist_message, env_name, suggested_value, configured_value)
-        super(assist_message)
+      def initialize(heuristic_name, assist_message, env_name, suggested_value, configured_value)
+        super(heuristic_name, assist_message)
         @env_name = env_name
         @suggested_value = suggested_value
         @configured_value = configured_value

--- a/lib/autotuner/report/single_environment_variable.rb
+++ b/lib/autotuner/report/single_environment_variable.rb
@@ -7,8 +7,8 @@ module Autotuner
       attr_reader :suggested_value
       attr_reader :configured_value
 
-      def initialize(assist_message, env_name, suggested_value, configured_value)
-        super(assist_message)
+      def initialize(heuristic_name, assist_message, env_name, suggested_value, configured_value)
+        super(heuristic_name, assist_message)
 
         @env_name = env_name
         @suggested_value = suggested_value

--- a/test/autotuner/heuristic/test_gc_compact.rb
+++ b/test/autotuner/heuristic/test_gc_compact.rb
@@ -23,6 +23,7 @@ module Autotuner
         report = gc_compact.tuning_report
 
         refute_nil(report)
+        assert_equal("GCCompact", report.heuristic_name)
 
         # Does not give report twice
         report = gc_compact.tuning_report

--- a/test/autotuner/heuristic/test_heap_size_warmup.rb
+++ b/test/autotuner/heuristic/test_heap_size_warmup.rb
@@ -22,6 +22,7 @@ module Autotuner
 
         report = @heap_size_warmup.tuning_report
 
+        assert_equal("HeapSizeWarmup", report.heuristic_name)
         assert_equal(HeapSizeWarmup::REPORT_ASSIST_MESSAGE, report.assist_message)
 
         if HeapSizeWarmup::SUPPORT_MULTI_HEAP_P

--- a/test/autotuner/heuristic/test_malloc.rb
+++ b/test/autotuner/heuristic/test_malloc.rb
@@ -60,6 +60,7 @@ module Autotuner
 
         report = @malloc.tuning_report
 
+        assert_equal("Malloc", report.heuristic_name)
         assert_includes(report.assist_message, "50.00%")
         assert_equal([Malloc::LIMIT_ENV, Malloc::LIMIT_MAX_ENV], report.env_name)
         assert_equal(

--- a/test/autotuner/heuristic/test_oldmalloc.rb
+++ b/test/autotuner/heuristic/test_oldmalloc.rb
@@ -51,6 +51,7 @@ module Autotuner
 
         report = @oldmalloc.tuning_report
 
+        assert_equal("Oldmalloc", report.heuristic_name)
         assert_includes(report.assist_message, "50.00%")
         assert_equal([Oldmalloc::LIMIT_ENV, Oldmalloc::LIMIT_MAX_ENV], report.env_name)
         assert_equal(

--- a/test/autotuner/heuristic/test_remembered_wb_unprotected_objects.rb
+++ b/test/autotuner/heuristic/test_remembered_wb_unprotected_objects.rb
@@ -53,6 +53,7 @@ module Autotuner
 
         report = @remembered_wb_unprotected_objects.tuning_report
 
+        assert_equal("WBUnprotectedObjects", report.heuristic_name)
         assert_includes(report.assist_message, "50.00%")
         assert_equal(RememberedWBUnprotectedObjects::LIMIT_RATIO_ENV, report.env_name)
         assert_equal(RememberedWBUnprotectedObjects::DEFAULT_LIMIT_RATIO * 2, report.suggested_value)

--- a/test/autotuner/report/test_multiple_environment_variables.rb
+++ b/test/autotuner/report/test_multiple_environment_variables.rb
@@ -5,11 +5,20 @@ require "test_helper"
 module Autotuner
   module Report
     class TestMultipleEnvironementVariables < Minitest::Test
+      def test_heuristic_name
+        msg = "Testing message\n"
+        env_name = ["TESTING_ONE", "TESTING_TWO"]
+        suggested_value = [12, 34]
+        report = MultipleEnvironmentVariables.new("test_heuristic", msg, env_name, suggested_value, [nil, nil])
+
+        assert_equal("test_heuristic", report.heuristic_name)
+      end
+
       def test_to_s
         msg = "Testing message\n"
         env_name = ["TESTING_ONE", "TESTING_TWO"]
         suggested_value = [12, 34]
-        report = MultipleEnvironmentVariables.new(msg, env_name, suggested_value, [nil, nil])
+        report = MultipleEnvironmentVariables.new("test_heuristic", msg, env_name, suggested_value, [nil, nil])
 
         assert_equal(<<~MSG, report.to_s)
           Testing message
@@ -26,7 +35,7 @@ module Autotuner
         msg = "Testing message\n"
         env_name = ["TESTING_ONE", "TESTING_TWO"]
         suggested_value = [12, 34]
-        report = MultipleEnvironmentVariables.new(msg, env_name, suggested_value, [nil, 10])
+        report = MultipleEnvironmentVariables.new("test_heuristic", msg, env_name, suggested_value, [nil, 10])
 
         assert_equal(<<~MSG, report.to_s)
           Testing message

--- a/test/autotuner/report/test_single_environement_variable.rb
+++ b/test/autotuner/report/test_single_environement_variable.rb
@@ -5,11 +5,20 @@ require "test_helper"
 module Autotuner
   module Report
     class TestSingleEnvironementVariable < Minitest::Test
+      def test_heuristic_name
+        msg = "Testing message\n"
+        env_name = "TESTING_ENV"
+        suggested_value = 123
+        report = SingleEnvironmentVariable.new("test_heuristic", msg, env_name, suggested_value, nil)
+
+        assert_equal("test_heuristic", report.heuristic_name)
+      end
+
       def test_to_s
         msg = "Testing message\n"
         env_name = "TESTING_ENV"
         suggested_value = 123
-        report = SingleEnvironmentVariable.new(msg, env_name, suggested_value, nil)
+        report = SingleEnvironmentVariable.new("test_heuristic", msg, env_name, suggested_value, nil)
 
         assert_equal(<<~MSG, report.to_s)
           Testing message
@@ -26,7 +35,7 @@ module Autotuner
         env_name = "TESTING_ENV"
         suggested_value = 123
         configured_value = 456
-        report = SingleEnvironmentVariable.new(msg, env_name, suggested_value, configured_value)
+        report = SingleEnvironmentVariable.new("test_heuristic", msg, env_name, suggested_value, configured_value)
 
         assert_equal(<<~MSG, report.to_s)
           Testing message


### PR DESCRIPTION
We want to log reports grouped by heuristic, as there's nothing in `Autotuner::Report::Base` that allows us to determine that we added this simple field to copy across.

We want our report function to look like this:

```ruby
Autotuner.reporter = proc do |report|
  Bugsnag.notify(Exception.new(report.heuristic_name)) do |payload|
    payload.add_tab(:autotuner, { report: report.to_s })
  end
end
```

Closes #11