### PR TITLE
Fix incorrect method signature in Heuristic::Base#call

### DIFF
--- a/lib/autotuner/heuristic/base.rb
+++ b/lib/autotuner/heuristic/base.rb
@@ -25,7 +25,7 @@ module Autotuner
         raise NotImplementedError
       end
 
-      def call(request_time, before_gc_context, after_gc_context)
+      def call(request_context)
         raise NotImplementedError
       end
 


### PR DESCRIPTION
## Summary
- Fix method signature mismatch in the base class that could confuse developers implementing custom heuristics

## Problem
The abstract `call` method in `Heuristic::Base` was declared as:
```ruby
def call(request_time, before_gc_context, after_gc_context)
```

But all five concrete implementations (Malloc, Oldmalloc, RememberedWBUnprotectedObjects, HeapSizeWarmup, GCCompact) use:
```ruby
def call(request_context)
```

This mismatch in the base class could mislead developers who want to implement custom heuristics, as they might follow the incorrect signature from the base class.

## Solution
Updated the base class signature to match the actual implementation: `def call(request_context)`